### PR TITLE
Fix button styles CSS syntax

### DIFF
--- a/src/lib/generators/vsl.js
+++ b/src/lib/generators/vsl.js
@@ -4,7 +4,6 @@ const generateVSLPage = (data) => {
   const [gtagAccount, gtagConversion] = (data.gtagId || '').split('/');
   const styles = data.styles || getRandomStyle();
   
-  // Generate random IDs
   const ids = {
     container: `container_${Math.random().toString(36).substr(2, 9)}`,
     video: `video_${Math.random().toString(36).substr(2, 9)}`,
@@ -13,7 +12,6 @@ const generateVSLPage = (data) => {
     footer: `footer_${Math.random().toString(36).substr(2, 9)}`
   };
 
-  // Google Ads tracking script
   const gtagScript = gtagAccount ? `
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
@@ -28,8 +26,7 @@ const generateVSLPage = (data) => {
     }
   ` : '';
 
-  return `
-    <!DOCTYPE html>
+  return `<!DOCTYPE html>
     <html lang="en">
     <head>
         <meta charset="UTF-8">
@@ -123,6 +120,8 @@ const generateVSLPage = (data) => {
                 width: 90%;
                 max-width: 500px;
             }
+
+            ${styles.buttonHover(styles.colors)}
 
             .description {
                 font-size: clamp(1rem, 3vw, 1.1rem);
@@ -251,8 +250,7 @@ const generateVSLPage = (data) => {
             </div>
         </footer>
     </body>
-    </html>
-  `;
+    </html>`;
 };
 
 export default generateVSLPage;

--- a/src/lib/utils/style-variations.js
+++ b/src/lib/utils/style-variations.js
@@ -51,20 +51,12 @@ const buttonStyles = [
     box-shadow: 0 4px 15px ${colors.primary}40;
     transform-origin: center;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    &:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 6px 20px ${colors.primary}60;
-    }
   `,
   (colors) => `
     background: linear-gradient(45deg, ${colors.primary}, ${colors.secondary});
     color: ${colors.text};
     box-shadow: 0 4px 15px ${colors.primary}30;
     transition: all 0.3s ease;
-    &:hover {
-      transform: translateY(-2px) scale(1.02);
-      box-shadow: 0 6px 25px ${colors.primary}50;
-    }
   `,
   (colors) => `
     background: linear-gradient(135deg, ${colors.secondary}, ${colors.primary}, ${colors.secondary});
@@ -72,7 +64,24 @@ const buttonStyles = [
     color: ${colors.text};
     box-shadow: 0 4px 15px ${colors.primary}30;
     transition: all 0.3s ease;
-    &:hover {
+  `
+];
+
+const buttonHoverStyles = [
+  (colors) => `
+    .cta-button:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 6px 20px ${colors.primary}60;
+    }
+  `,
+  (colors) => `
+    .cta-button:hover {
+      transform: translateY(-2px) scale(1.02);
+      box-shadow: 0 6px 25px ${colors.primary}50;
+    }
+  `,
+  (colors) => `
+    .cta-button:hover {
       background-position: right center;
       transform: translateY(-2px);
       box-shadow: 0 6px 20px ${colors.primary}50;
@@ -110,7 +119,9 @@ const getRandomStyle = () => {
   const accent = getRandomVariation(colors.accents);
   const background = getRandomVariation(colors.backgrounds);
   const font = getRandomVariation(fonts);
-  const button = getRandomVariation(buttonStyles);
+  const buttonIndex = Math.floor(Math.random() * buttonStyles.length);
+  const button = buttonStyles[buttonIndex];
+  const buttonHover = buttonHoverStyles[buttonIndex];
   const image = getRandomVariation(imageStyles);
   const container = getRandomVariation(containerStyles);
 
@@ -119,6 +130,7 @@ const getRandomStyle = () => {
     background,
     fonts: font,
     button: (colors) => button(colors || accent),
+    buttonHover: (colors) => buttonHover(colors || accent),
     image,
     container,
     borderRadius: Math.floor(Math.random() * 3) * 4 + 8 + 'px',  // 8px, 12px, or 16px
@@ -129,4 +141,4 @@ const getRandomStyle = () => {
   };
 };
 
-export { getRandomStyle, getRandomVariation, colors, fonts, buttonStyles, imageStyles, containerStyles };
+export { getRandomStyle, getRandomVariation, colors, fonts, buttonStyles, buttonHoverStyles, imageStyles, containerStyles };


### PR DESCRIPTION
This PR fixes the 500 error in the generation endpoint by:

1. Separating button styles and hover styles in style-variations.js
2. Updating the VSL generator to properly apply the hover styles
3. Removing CSS-in-JS syntax (&:hover) that doesn't work in plain CSS strings

To implement this fix manually:

1. In src/lib/utils/style-variations.js:
- Remove &:hover syntax from buttonStyles
- Add new buttonHoverStyles array with hover styles
- Update getRandomStyle to return buttonHover function

2. In src/lib/generators/vsl.js:
- Add ${styles.buttonHover(styles.colors)} after the .cta-button styles

These changes ensure the CSS is valid and the button hover effects work properly.